### PR TITLE
Fix sinon.stub on window object with latest sinon

### DIFF
--- a/addon-test-support/-private/mock/proxy.js
+++ b/addon-test-support/-private/mock/proxy.js
@@ -33,6 +33,15 @@ export default function proxyFactory(original) {
       delete target[prop];
       return true;
     },
+    getOwnPropertyDescriptor(target, property) {
+      return (
+        Reflect.getOwnPropertyDescriptor(holder, property) ??
+        Reflect.getOwnPropertyDescriptor(target, property)
+      );
+    },
+    defineProperty(target, property, attributes) {
+      return Reflect.defineProperty(holder, property, attributes);
+    },
   });
 
   return proxy;

--- a/addon-test-support/-private/window.js
+++ b/addon-test-support/-private/window.js
@@ -69,6 +69,15 @@ export const mockProxyHandler = {
     delete target[prop];
     return true;
   },
+  getOwnPropertyDescriptor(target, property) {
+    return (
+      Reflect.getOwnPropertyDescriptor(holder, property) ??
+      Reflect.getOwnPropertyDescriptor(target, property)
+    );
+  },
+  defineProperty(target, property, attributes) {
+    return Reflect.defineProperty(holder, property, attributes);
+  },
 };
 
 export function reset() {

--- a/addon/index.js
+++ b/addon/index.js
@@ -23,6 +23,8 @@ if (DEBUG) {
     set: Reflect.set,
     has: Reflect.has,
     deleteProperty: Reflect.deleteProperty,
+    getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
+    defineProperty: Reflect.defineProperty,
   };
 
   let currentHandler = doNothingHandler;
@@ -43,6 +45,12 @@ if (DEBUG) {
     },
     deleteProperty() {
       return currentHandler.deleteProperty(...arguments);
+    },
+    getOwnPropertyDescriptor() {
+      return currentHandler.getOwnPropertyDescriptor(...arguments);
+    },
+    defineProperty() {
+      return currentHandler.defineProperty(...arguments);
     },
   };
 

--- a/tests/unit/sinon-test.js
+++ b/tests/unit/sinon-test.js
@@ -18,14 +18,12 @@ module('sinon', function (hooks) {
     assert.true(window.testFn.calledOnce);
   });
 
-  // TODO: https://github.com/simonihmig/ember-window-mock/issues/478
-  test.skip('it can stub window.confirm', function (assert) {
+  test('it can stub window.confirm', function (assert) {
     sinon.stub(window, 'confirm').returns(true);
     assert.true(window.confirm(), 'window.confirm can be stubbed');
   });
 
-  // this fails inside sinon with `Attempted to wrap undefined property fetch as function`, as it does some weird things that seem to not play nicely with our Proxies
-  test.skip('it can spy on window.fetch', function (assert) {
+  test('it can spy on window.fetch', function (assert) {
     sinon.spy(window, 'fetch');
     window.fetch();
     assert.true(window.fetch.calledOnce, 'window.fetch can be spied on');


### PR DESCRIPTION
The proxy did not support all handlers like `getOwnPropertyDescriptor` and `defineProperty`, which did not play nicely with the latest sinon versions. Fixes #478