### PR TITLE
Revert "Support mocking window.location.origin"

### DIFF
--- a/ember-window-mock/src/test-support/-private/mock/location.js
+++ b/ember-window-mock/src/test-support/-private/mock/location.js
@@ -4,6 +4,7 @@ const mappedProperties = [
   'host',
   'hostname',
   'hash',
+  'origin',
   'search',
   'pathname',
   'protocol',
@@ -22,7 +23,6 @@ const mappedProperties = [
 export default function locationFactory(defaultUrl) {
   let location = {};
   let url = new URL(defaultUrl);
-  let mockedValues = {};
 
   mappedProperties.forEach((propertyName) => {
     Object.defineProperty(location, propertyName, {
@@ -33,15 +33,6 @@ export default function locationFactory(defaultUrl) {
         url[propertyName] = value;
       },
     });
-  });
-
-  Object.defineProperty(location, 'origin', {
-    get() {
-      return mockedValues.origin ?? url.origin;
-    },
-    set(value) {
-      mockedValues.origin = value;
-    },
   });
 
   Object.defineProperty(location, 'href', {

--- a/test-app/tests/unit/window-mock-test.ts
+++ b/test-app/tests/unit/window-mock-test.ts
@@ -124,19 +124,8 @@ module('window-mock', function (hooks) {
 
     test('it mocks window.location', function (assert) {
       // @ts-expect-error - this actually works
-      // > Though Window.location is a read-only Location object, you can also assign a string to it. This means that you can work with location as if it were a string in most cases: location = 'http://www.example.com' is a synonym of location.href = 'http://www.example.com'.
-      // See https://developer.mozilla.org/en-US/docs/Web/API/Window/location
       window.location = 'http://www.example.com';
       assert.strictEqual(window.location.href, 'http://www.example.com/');
-    });
-
-    test('it mocks window.location.origin', function (assert) {
-      // @ts-expect-error - we allow this when mocked
-      window.location.origin = 'http://www.example.com:8080/foo?q=bar#hash';
-      assert.strictEqual(
-        window.location.origin,
-        'http://www.example.com:8080/foo?q=bar#hash',
-      );
     });
 
     test('it mocks window.location.reload', function (assert) {


### PR DESCRIPTION
The change was wrong, `origin` is read-only and should just follow what you set via `window.location.href`, no need to have it diverge as this cannot happen in a real browser API.