### PR TITLE
Fix default export positions

### DIFF
--- a/ember-window-mock/package.json
+++ b/ember-window-mock/package.json
@@ -10,12 +10,12 @@
   "author": "Simon Ihmig <simon.ihmig@gmail.com>",
   "exports": {
     ".": {
-      "default": "./src/index.js",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./src/index.js"
     },
     "./test-support": {
-      "default": "./src/test-support/index.js",
-      "types": "./index.d.ts"
+      "types": "./index.d.ts",
+      "default": "./src/test-support/index.js"
     },
     "./addon-main.js": "./addon-main.cjs"
   },


### PR DESCRIPTION
I was eager to update because it would let me [remove a peer dependency override](https://github.com/cardstack/boxel/pull/1453/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L37) but I saw [build failures](https://github.com/cardstack/boxel/actions/runs/10063099746) in the application that consumes `ember-window-mock`. Unfortunately I can’t find the errors to link to in CI but when I ran locally I saw this for every file that imports from the addon:

```
ERROR in ./components/ai-assistant/panel.ts 12:0-39
Module not found: Error: Default condition should be last one
 @ ./tests/integration/components/ai-assistant-panel-test.ts 14:0-92 1221:32-59 1225:35-62
 @ ./assets/test.js 179:13-95

ERROR in ./components/ai-assistant/toast.ts 11:0-39
Module not found: Error: Default condition should be last one
 @ ./components/operator-mode/submode-layout.ts 22:0-77 292:113-129
 @ ./components/operator-mode/code-submode.ts 28:0-45 862:18-31
 @ ./components/operator-mode/container.ts 21:0-80 184:48-59
 @ ./tests/integration/components/ai-assistant-panel-test.ts 21:0-78 461:22-34 529:22-34 1174:22-34 1205:22-34 1288:22-34 1387:22-34 1947:22-34
 @ ./assets/test.js 179:13-95
```

Looking at the [Node documentation on exports](https://nodejs.org/api/packages.html#conditional-exports):

> `"default"` - the generic fallback that always matches. Can be a CommonJS or ES module file. _This condition should always come last._

I added a [pnpm patch identical to this PR](https://github.com/cardstack/boxel/pull/1453/commits/4761fd47e4fd934b919bd0d54321d5ccdada7363) and the build succeeded locally [and in CI](https://github.com/cardstack/boxel/actions/runs/10064419047) (apart from a known infrastructure problem).

Thanks for the continuing work on this, so useful!