### PR TITLE
Fix type error in type declaration

### DIFF
--- a/ember-window-mock/index.d.ts
+++ b/ember-window-mock/index.d.ts
@@ -1,3 +1,5 @@
+type GlobalWindow = typeof window;
+
 declare module 'ember-window-mock' {
   export default window;
 }
@@ -6,6 +8,6 @@ declare module 'ember-window-mock/test-support' {
   export function setupWindowMock(hooks: {
     afterEach: (fn: () => void) => void;
   }): void;
-  export function reset(window?: typeof window): void;
-  export function createMockedWindow(window?: typeof window): typeof window;
+  export function reset(window?: GlobalWindow): void;
+  export function createMockedWindow(window?: GlobalWindow): GlobalWindow;
 }


### PR DESCRIPTION
`'window' is referenced directly or indirectly in its own type annotation.ts(2502)` showing up, probably in more recent TS versions.