### PR TITLE
Always use proxy to window, fixes #602

### DIFF
--- a/ember-window-mock/package.json
+++ b/ember-window-mock/package.json
@@ -39,8 +39,7 @@
     "test": "echo 'A v2 addon does not have tests, run tests in test-app'"
   },
   "dependencies": {
-    "@embroider/addon-shim": "^1.8.7",
-    "@embroider/macros": "^1.16.5"
+    "@embroider/addon-shim": "^1.8.7"
   },
   "devDependencies": {
     "concurrently": "9.2.1",

--- a/ember-window-mock/src/index.js
+++ b/ember-window-mock/src/index.js
@@ -1,63 +1,54 @@
-import { macroCondition, isTesting } from '@embroider/macros';
+// this Proxy handler will be used to preserve the unaltered behavior of the window global by default
+const doNothingHandler = {
+  get(target, prop) {
+    const value = Reflect.get(target, prop);
 
-let exportedWindow;
-let _setCurrentHandler;
+    // make sure the function receives the original window as the this context! (e.g. alert will throw an invalid invocation error)
+    if (typeof value === 'function') {
+      return new Proxy(value, {
+        apply(t, _thisArg, argumentsList) {
+          return Reflect.apply(value, target, argumentsList);
+        },
+      });
+    }
 
-if (macroCondition(isTesting())) {
-  // this Proxy handler will be used to preserve the unaltered behavior of the window global by default
-  const doNothingHandler = {
-    get(target, prop) {
-      const value = Reflect.get(target, prop);
+    return value;
+  },
+  set: Reflect.set,
+  has: Reflect.has,
+  deleteProperty: Reflect.deleteProperty,
+  getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
+  defineProperty: Reflect.defineProperty,
+};
 
-      // make sure the function receives the original window as the this context! (e.g. alert will throw an invalid invocation error)
-      if (typeof value === 'function') {
-        return new Proxy(value, {
-          apply(t, _thisArg, argumentsList) {
-            return Reflect.apply(value, target, argumentsList);
-          },
-        });
-      }
+let currentHandler = doNothingHandler;
 
-      return value;
-    },
-    set: Reflect.set,
-    has: Reflect.has,
-    deleteProperty: Reflect.deleteProperty,
-    getOwnPropertyDescriptor: Reflect.getOwnPropertyDescriptor,
-    defineProperty: Reflect.defineProperty,
-  };
+// private function to replace the default handler in tests
+const _setCurrentHandler = (handler = doNothingHandler) =>
+  (currentHandler = handler);
 
-  let currentHandler = doNothingHandler;
+const proxyHandler = {
+  get() {
+    return currentHandler.get(...arguments);
+  },
+  set() {
+    return currentHandler.set(...arguments);
+  },
+  has() {
+    return currentHandler.has(...arguments);
+  },
+  deleteProperty() {
+    return currentHandler.deleteProperty(...arguments);
+  },
+  getOwnPropertyDescriptor() {
+    return currentHandler.getOwnPropertyDescriptor(...arguments);
+  },
+  defineProperty() {
+    return currentHandler.defineProperty(...arguments);
+  },
+};
 
-  // private function to replace the default handler in tests
-  _setCurrentHandler = (handler = doNothingHandler) =>
-    (currentHandler = handler);
-
-  const proxyHandler = {
-    get() {
-      return currentHandler.get(...arguments);
-    },
-    set() {
-      return currentHandler.set(...arguments);
-    },
-    has() {
-      return currentHandler.has(...arguments);
-    },
-    deleteProperty() {
-      return currentHandler.deleteProperty(...arguments);
-    },
-    getOwnPropertyDescriptor() {
-      return currentHandler.getOwnPropertyDescriptor(...arguments);
-    },
-    defineProperty() {
-      return currentHandler.defineProperty(...arguments);
-    },
-  };
-
-  exportedWindow = new Proxy(window, proxyHandler);
-} else {
-  exportedWindow = window;
-}
+const exportedWindow = new Proxy(window, proxyHandler);
 
 export default exportedWindow;
 export { _setCurrentHandler };

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -30,7 +30,6 @@
     "@ember/optional-features": "2.3.0",
     "@ember/string": "4.0.1",
     "@ember/test-helpers": "5.4.2",
-    "@embroider/macros": "1.19.7",
     "@embroider/test-setup": "4.0.0",
     "@glimmer/component": "2.1.1",
     "@glimmer/tracking": "1.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1142,21 +1142,7 @@
     common-ancestor-path "^1.0.1"
     semver "^7.3.8"
 
-"@embroider/macros@1.19.7":
-  version "1.19.7"
-  resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.19.7.tgz#2cbea2423b2332ec38b99e9f904976e10ab2f686"
-  integrity sha512-KOdoJ2QwNpWFwRP8q4CutMjs4QAgZ0rjNJAO+hYZkWFxM3DOQFyqvImNDx0m/Z/sXEnE1XwUN8NpMCNYyq801A==
-  dependencies:
-    "@embroider/shared-internals" "3.0.2"
-    assert-never "^1.2.1"
-    babel-import-util "^3.0.1"
-    ember-cli-babel "^7.26.6 || ^8.3.1"
-    find-up "^5.0.0"
-    lodash "^4.17.21"
-    resolve "^1.20.0"
-    semver "^7.3.2"
-
-"@embroider/macros@^1.0.0", "@embroider/macros@^1.16.12", "@embroider/macros@^1.16.5", "@embroider/macros@^1.16.9", "@embroider/macros@^1.18.1", "@embroider/macros@^1.20.2":
+"@embroider/macros@^1.0.0", "@embroider/macros@^1.16.12", "@embroider/macros@^1.16.9", "@embroider/macros@^1.18.1", "@embroider/macros@^1.20.2":
   version "1.20.3"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.20.3.tgz#6f95da777ffcfcd71c84ff79510a4ada11fcdc86"
   integrity sha512-8sClktPsQ20KgnWl8id6NL5G/hv3+Q5OlnQ4y4XQjYS/RsPy8/C9tU75/2ujgToi1YfX64UykjCau6PXqKDfUQ==
@@ -1177,25 +1163,6 @@
   dependencies:
     mem "^8.0.0"
     resolve.exports "^2.0.2"
-
-"@embroider/shared-internals@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@embroider/shared-internals/-/shared-internals-3.0.2.tgz#0e10926956f682e3dd5621b911e4c3eb36df3816"
-  integrity sha512-/SusdG+zgosc3t+9sPFVKSFOYyiSgLfXOT6lYNWoG1YtnhWDxlK4S8leZ0jhcVjemdaHln5rTyxCnq8oFLxqpQ==
-  dependencies:
-    babel-import-util "^3.0.1"
-    debug "^4.3.2"
-    ember-rfc176-data "^0.3.17"
-    fs-extra "^9.1.0"
-    is-subdir "^1.2.0"
-    js-string-escape "^1.0.1"
-    lodash "^4.17.21"
-    minimatch "^3.0.4"
-    pkg-entry-points "^1.1.1"
-    resolve-package-path "^4.0.1"
-    resolve.exports "^2.0.2"
-    semver "^7.3.5"
-    typescript-memoize "^1.0.1"
 
 "@embroider/shared-internals@3.1.0", "@embroider/shared-internals@^3.0.1":
   version "3.1.0"


### PR DESCRIPTION
This is _just_ an attempt to fix using `isTesting` in module scope #602.

AFAICT, it feels fine to expect that `import window from 'ember-window-mock'` returns something like `window`, otherwise direct use of global `window` could be used instead. Hence no need for `isTesting` check? 🤔

[Hide whitespace](https://github.com/simonihmig/ember-window-mock/pull/608/changes?w=1) 👀